### PR TITLE
Ensure root permissions unless --dry-run is set

### DIFF
--- a/opensuse-migration-tool
+++ b/opensuse-migration-tool
@@ -95,7 +95,6 @@ function populate_options() {
 # Elevated permissions check unless DRYRUN is set
 if [ -z "${DRYRUN:-}" ]; then
     if [ "$EUID" -ne 0 ]; then
-        echo "This script requires root privileges if --dry-run is not set"
         exec sudo "$0" "$@"
     fi
 fi

--- a/opensuse-migration-tool
+++ b/opensuse-migration-tool
@@ -91,6 +91,15 @@ function populate_options() {
         fi
     done <<<"$versions"
 }
+
+# Elevated permissions check unless DRYRUN is set
+if [ -z "${DRYRUN:-}" ]; then
+    if [ "$EUID" -ne 0 ]; then
+        echo "This script requires root privileges if --dry-run is not set"
+        exec sudo "$0" "$@"
+    fi
+fi
+
 # System-specific options
 if [[ "$NAME" == "openSUSE Leap Micro" ]]; then
     MIGRATION_OPTIONS["$CURRENT_INDEX"]="MicroOS"


### PR DESCRIPTION
Fixes #9 

* Check for UID=0 run with sudo if we're not root.
* No need to re-type root password on each execution in e.g. devcontainers thanks to sudo re-exec

![image](https://github.com/user-attachments/assets/eb55e84e-4523-4e61-8332-77cb9623dc26)
