### PR TITLE
Allow migration from Tumbleweed to Slowroll

### DIFF
--- a/opensuse-migration-tool
+++ b/opensuse-migration-tool
@@ -157,7 +157,7 @@ done
 # Display dialog and get choice
 CHOICE=$(dialog --clear \
     --title "[EXPERIMENTAL] System Migration - NOT FOR PRODUCTION" \
-    --menu "Select the migration target:" \
+    --menu "Select the migration target from $NAME:" \
     20 60 10 \
     "${DIALOG_ITEMS[@]}" \
     2>&1 >/dev/tty) || exit

--- a/opensuse-migration-tool
+++ b/opensuse-migration-tool
@@ -124,17 +124,30 @@ elif [[ "$NAME" == "openSUSE Leap" ]]; then
     else
         populate_options "Leap" "$VERSION" '.state=="Stable"'
     fi
+elif [[ "$NAME" == "openSUSE Tumbleweed" ]]; then
+   MIGRATION_OPTIONS["$CURRENT_INDEX"]="openSUSE Tumbleweed-Slowroll"
+   ((CURRENT_INDEX++))
+   echo
 elif [[ "$NAME" == "openSUSE Tumbleweed-Slowroll" ]]; then
     MIGRATION_OPTIONS["$CURRENT_INDEX"]="openSUSE Tumbleweed"
     ((CURRENT_INDEX++))
 else
-    echo "Unsupported system type: '$NAME'" >&2
+    dialog --clear \
+    --title "[EXPERIMENTAL] System Migration - NOT FOR PRODUCTION" \
+	--msgbox "\nMigration from $NAME is currently not supported.\n\nPlease report issue at https://github.com/openSUSE/opensuse-migration-tool" \
+    10 60
     exit 1
 fi
+
 # Display migration options
 if [[ ${#MIGRATION_OPTIONS[@]} -eq 0 ]]; then
-    echo "No migration options available."
+    dialog --clear \
+    --title "[EXPERIMENTAL] System Migration - NOT FOR PRODUCTION" \
+	--msgbox "\nNo migration options available from $NAME.\n\nPlease report issue at https://github.com/openSUSE/opensuse-migration-tool." \
+    10 60
     exit 1
+    echo "."
+
 fi
 # Prepare dialog items
 DIALOG_ITEMS=()
@@ -323,7 +336,7 @@ EOL
                 exit 1
             fi
             $DRYRUN zypper addrepo -f $REPOURL $TMP_REPO_NAME
-            $DRYRUN zypper in -y --from $TMP_REPO_NAME openSUSE-repos-Leap # install repos from the nextrelease
+            $DRYRUN zypper in -y --from $TMP_REPO_NAME openSUSE-repos-Slowroll # install repos from the nextrelease
             $DRYRUN zypper removerepo $TMP_REPO_NAME # drop the temp repo, we have now definitions of all repos we need
             $DRYRUN zypper refs # !Important! make sure that all repo files under index service were regenerated
             
@@ -374,7 +387,7 @@ EOL
                 fi
             fi
             $DRYRUN zypper addrepo -f $REPOURL $TMP_REPO_NAME
-            $DRYRUN zypper in -y --from $TMP_REPO_NAME openSUSE-repos-MicroOS # install repos from the nextrelease
+			$DRYRUN zypper in -y --from $TMP_REPO_NAME openSUSE-repos-MicroOS # install repos from the nextrelease
             $DRYRUN zypper removerepo $TMP_REPO_NAME # drop the temp repo, we have now definitions of all repos we need
             $DRYRUN zypper refs # !Important! make sure that all repo files under index service were regenerated
             


### PR DESCRIPTION
* Fix accidental installation of openSUSE-repos-Leap when Slowroll is migration target (copy paste error)

* Use dialog to notify user about unsupported scenario.

The screenshot before adding slowroll as an option, but after using dialog instead of echo
![image](https://github.com/user-attachments/assets/abe110ae-2f76-469c-b7a7-1205e5e6aacb)

Dialog after enabling Slowroll as migration target from Tumbleweed
![image](https://github.com/user-attachments/assets/b5e55caf-9bd9-40bc-aa89-f7d0d9f6a9ec)
