### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This project is licensed under the [Apache-2.0 License](http://www.apache.org/li
 
 ```bash
 sudo zypper in opensuse-migration-tool
-opensuse-migration-tool --dry-run
+/usr/sbin/opensuse-migration-tool --dry-run
 sudo opensuse-migration-tool
 reboot
 ```


### PR DESCRIPTION
On regular system, opensuse-migration-tool is not in default directory, is in /usr/sbin/