### PR TITLE
fix: remove the check for x86-64-v3 flag `movbe` from the v2 check

### DIFF
--- a/opensuse-migration-tool
+++ b/opensuse-migration-tool
@@ -130,7 +130,7 @@ function populate_options() {
 
 # Required x86_64-v2 flags
 #required_v2_flags=("cx16" "sse4_1" "sse4_2" "popcnt" "movbe" "xsave")
-required_v2_flags=("cx16" "sse4_1" "sse4_2" "popcnt" "movbe" "xsave")
+required_v2_flags=("cx16" "sse4_1" "sse4_2" "popcnt" "xsave")
 
 # Required x86_64-v3 flags
 #required_v3_flags=("cx16" "sse4_1" "sse4_2" "popcnt" "movbe" "xsave" "avx" "avx2" "bmi1" "bmi2" "fma" "abm")


### PR DESCRIPTION
The `movbe` flag is a v3 flag, but it was included in the v2 check.

I've tested the changes on real hardware, and it works !

Closes: https://github.com/openSUSE/opensuse-migration-tool/issues/41