### PR TITLE
don't install selinux-policy-targeted-gaming by default

### DIFF
--- a/scripts/10_keepselinux.sh
+++ b/scripts/10_keepselinux.sh
@@ -58,7 +58,5 @@ if rpm -q patterns-base-apparmor &>/dev/null; then
     fi
 fi
 # user said he wants SElinux, so install SElinux pattern
-log "Installing packages: patterns-selinux selinux-policy-targeted-gaming"
+log "Installing packages: patterns-selinux"
 $DRYRUN zypper --non-interactive install -t pattern --force-resolution selinux
-# this SElinux package is providing rules for gaming
-$DRYRUN zypper --non-interactive install selinux-policy-targeted-gaming


### PR DESCRIPTION
selinux-policy-targeted-gaming weakens the security posture of the system and should only be installed if really needed