### PR TITLE
Explicitly disable SELinux when no Linux Security Module was selected

### DIFF
--- a/opensuse-migration-tool
+++ b/opensuse-migration-tool
@@ -510,6 +510,7 @@ for script in "$POST_MIGRATION_DIR"/*.sh; do
     name=$(basename "$script" .sh)
     if "$script" --check; then
         case "$name" in
+            "10_disableselinux") desc="Disable SELinux" ;;
             "10_keepapparmor") desc="Keep AppArmor (SELinux is the new default)" ;;
             "10_keepselinux") desc="Switch to SELinux (new default)" ;;
             "20_pulse2pipewire") desc="Switch to PipeWire (new default)" ;;

--- a/scripts/10_disableselinux.sh
+++ b/scripts/10_disableselinux.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Explicitly disable SELinux when no Linux Security Module was selected.
+# Newer kernels enable SELinux by default if no LSM is specified, which
+# breaks migrated systems without SELinux userspace installed.
+#
+# https://github.com/openSUSE/opensuse-migration-tool/issues/69
+
+set -euo pipefail
+
+# Elevated permissions check unless DRYRUN is set
+if [ -z "${DRYRUN:-}" ]; then
+    if [ "$EUID" -ne 0 ]; then
+        exec sudo "$0" "$@"
+    fi
+    test -w / || {
+        echo "Please run the tool inside 'transactional-update shell' on Immutable systems."
+        exit 1
+    }
+fi
+
+UPDATE_BOOTLOADER=$(command -v update-bootloader)
+
+if [ -z "$UPDATE_BOOTLOADER" ]; then
+    echo -e "No update-bootloader found!\n"
+    exit 0
+fi
+
+log() {
+    echo "[MIGRATION] $1"
+}
+
+# --check mode:
+# return 0 if no LSM is configured (script should run)
+# return 1 otherwise
+if [[ "${1:-}" == "--check" ]]; then
+    if ! $UPDATE_BOOTLOADER --get-option security | grep -Eq '(selinux|apparmor)'; then
+        exit 0
+    else
+        exit 1
+    fi
+fi
+
+log "No security module selected, explicitly disabling SELinux"
+
+$DRYRUN update-bootloader --del-option "security=selinux"
+$DRYRUN update-bootloader --del-option "enforcing=1"
+$DRYRUN update-bootloader --del-option "selinux=1"
+$DRYRUN update-bootloader --add-option "selinux=0"


### PR DESCRIPTION
This option is useful when migrating systems where neither AppArmor nor SELinux is intended to be used after the migration.

On newer kernels, SELinux may be enabled by default if no Linux Security Module is specified on the kernel command line. On systems that do not have SELinux userspace, policies, or labeling configured, this can lead to boot failures or malfunctioning services (for example, dbus or systemd).

Selecting this option ensures that SELinux is explicitly disabled in the kernel configuration, preserving the user’s intent and preventing unintended activation of SELinux during or after migration.

Typical use cases include:

- Migrations where the administrator plans to configure a security framework later
- Minimal or appliance-like systems where no LSM is desired
- Systems previously using AppArmor where no replacement is selected during migration

Fix #69