### PR TITLE
Ensure update bootloader is installed in post scripts

### DIFF
--- a/scripts/10_keepapparmor.sh
+++ b/scripts/10_keepapparmor.sh
@@ -32,6 +32,13 @@ error_exit() {
     exit 1
 }
 
+# Ensure update-bootloader is available (Leap 16+)
+if ! command -v update-bootloader >/dev/null 2>&1; then
+    log "update-bootloader not found, installing it"
+    $DRYRUN zypper --non-interactive install --force-resolution update-bootloader \
+        || error_exit "Failed to install update-bootloader"
+fi
+
 # Check if we have security=apparmor as boot param
 if [[ "${1:-}" == "--check" ]]; then
     if ! $UPDATE_BOOTLOADER --get-option security | grep apparmor &>/dev/null; then

--- a/scripts/10_keepselinux.sh
+++ b/scripts/10_keepselinux.sh
@@ -32,6 +32,13 @@ error_exit() {
     exit 1
 }
 
+# Ensure update-bootloader is available (Leap 16+)
+if ! command -v update-bootloader >/dev/null 2>&1; then
+    log "update-bootloader not found, installing it"
+    $DRYRUN zypper --non-interactive install --force-resolution update-bootloader \
+        || error_exit "Failed to install update-bootloader"
+fi
+
 # Check if we have security=selinux as boot param
 if [[ "${1:-}" == "--check" ]]; then
     if ! $UPDATE_BOOTLOADER --get-option security | grep selinux &>/dev/null; then


### PR DESCRIPTION
Leap 15.6 doesn't have update-bootloader package in repo, but it's available as the migraton target Leap 16.0/TW/Slowroll. 15.6 is EOL as of April 2026, so I'll skip release checks, as the only migration targets post this date will have update-bootloader available.

Therefore we should only install it from the post-script and don't make it general Requires for the package see https://build.opensuse.org/projects/Base:System/packages/opensuse-migration-tool/files/opensuse-migration-tool.spec?expand=1