### PR TITLE
Handle prerelease states add local distributions.json fallback

### DIFF
--- a/.github/workflows/check-distributions-json.yml
+++ b/.github/workflows/check-distributions-json.yml
@@ -10,7 +10,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Fetch live distributions.json
-        run: curl -sf https://get.opensuse.org/api/v0/distributions.json | jq --sort-keys . > /tmp/live.json
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -sf https://get.opensuse.org/api/v0/distributions.json | jq --sort-keys . > /tmp/live.json
 
       - name: Normalize local distributions.json
         run: jq --sort-keys . distributions.json > /tmp/local.json

--- a/.github/workflows/check-distributions-json.yml
+++ b/.github/workflows/check-distributions-json.yml
@@ -1,0 +1,26 @@
+name: Check distributions.json is up to date
+
+on:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch live distributions.json
+        run: curl -sf https://get.opensuse.org/api/v0/distributions.json | jq --sort-keys . > /tmp/live.json
+
+      - name: Normalize local distributions.json
+        run: jq --sort-keys . distributions.json > /tmp/local.json
+
+      - name: Diff local vs live
+        run: |
+          if ! diff -u /tmp/local.json /tmp/live.json; then
+            echo ""
+            echo "::error::distributions.json is out of date."
+            echo "Run: curl -s https://get.opensuse.org/api/v0/distributions.json | jq . > distributions.json"
+            exit 1
+          fi
+          echo "distributions.json is up to date."

--- a/README.md
+++ b/README.md
@@ -179,6 +179,22 @@ osc sr openSUSE:Factory opensuse-migration-tool openSUSE:Leap:15.6:Update
 
 ---
 
+## 🗂️ Keeping `distributions.json` Up to Date
+
+The `distributions.json` file in the repository root is a local fallback used when `get.opensuse.org` is unreachable (e.g. offline development, network outage). It mirrors the data served by the [get.opensuse.org API](https://get.opensuse.org/api/v0/distributions.json).
+
+**This file must be updated whenever a Leap milestone changes state** — for example when Leap 16.1 moves from Alpha → Beta → RC → Stable, or when a new version is added or reaches EOL.
+
+To update it:
+
+```bash
+curl -s https://get.opensuse.org/api/v0/distributions.json | jq . > distributions.json
+```
+
+Commit the updated file alongside any release-related changes.
+
+---
+
 ## 🤝 Contributions Welcome!
 
 We're happy to receive PRs, testing reports, or feedback on supported scenarios.

--- a/distributions.json
+++ b/distributions.json
@@ -1,0 +1,222 @@
+{
+  "Leap": [
+    {
+      "name": "openSUSE Leap",
+      "version": "16.1",
+      "state": "Alpha",
+      "upgrade-weight": 11
+    },
+    {
+      "name": "openSUSE Leap",
+      "version": "16.0",
+      "state": "Stable",
+      "upgrade-weight": 10
+    },
+    {
+      "name": "openSUSE Leap",
+      "version": "15.6",
+      "state": "Stable",
+      "upgrade-weight": 9
+    },
+    {
+      "name": "openSUSE Leap",
+      "version": "15.5",
+      "state": "EOL",
+      "upgrade-weight": 8
+    },
+    {
+      "name": "openSUSE Leap",
+      "version": "15.4",
+      "state": "EOL",
+      "upgrade-weight": 7
+    },
+    {
+      "name": "openSUSE Leap",
+      "version": "15.3",
+      "state": "EOL",
+      "upgrade-weight": 6
+    },
+    {
+      "name": "openSUSE Leap",
+      "version": "15.2",
+      "state": "EOL",
+      "upgrade-weight": 5
+    },
+    {
+      "name": "openSUSE Leap",
+      "version": "15.1",
+      "state": "EOL",
+      "upgrade-weight": 4
+    },
+    {
+      "name": "openSUSE Leap",
+      "version": "15.0",
+      "state": "EOL",
+      "upgrade-weight": 3
+    },
+    {
+      "name": "openSUSE Leap",
+      "version": "42.3",
+      "state": "EOL",
+      "upgrade-weight": 2
+    },
+    {
+      "name": "openSUSE Leap",
+      "version": "42.2",
+      "state": "EOL",
+      "upgrade-weight": 1
+    },
+    {
+      "name": "openSUSE Leap",
+      "version": "42.1",
+      "state": "EOL",
+      "upgrade-weight": 0
+    }
+  ],
+  "LeapMicro": [
+    {
+      "name": "openSUSE Leap Micro",
+      "version": "6.2",
+      "state": "Stable",
+      "upgrade-weight": 6
+    },
+    {
+      "name": "openSUSE Leap Micro",
+      "version": "6.1",
+      "state": "Stable",
+      "upgrade-weight": 6
+    },
+    {
+      "name": "openSUSE Leap Micro",
+      "version": "6.0",
+      "state": "EOL",
+      "upgrade-weight": 5
+    },
+    {
+      "name": "openSUSE Leap Micro",
+      "version": "5.5",
+      "state": "EOL",
+      "upgrade-weight": 4
+    },
+    {
+      "name": "openSUSE Leap Micro",
+      "version": "5.4",
+      "state": "EOL",
+      "upgrade-weight": 3
+    },
+    {
+      "name": "openSUSE Leap Micro",
+      "version": "5.3",
+      "state": "EOL",
+      "upgrade-weight": 2
+    },
+    {
+      "name": "openSUSE Leap Micro",
+      "version": "5.2",
+      "state": "EOL",
+      "upgrade-weight": 1
+    }
+  ],
+  "Tumbleweed": [
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260515",
+      "upgrade-weight": 20260515
+    },
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260514",
+      "upgrade-weight": 20260514
+    },
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260512",
+      "upgrade-weight": 20260512
+    },
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260511",
+      "upgrade-weight": 20260511
+    },
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260510",
+      "upgrade-weight": 20260510
+    },
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260509",
+      "upgrade-weight": 20260509
+    },
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260507",
+      "upgrade-weight": 20260507
+    },
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260506",
+      "upgrade-weight": 20260506
+    },
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260505",
+      "upgrade-weight": 20260505
+    },
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260504",
+      "upgrade-weight": 20260504
+    },
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260430",
+      "upgrade-weight": 20260430
+    },
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260429",
+      "upgrade-weight": 20260429
+    },
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260428",
+      "upgrade-weight": 20260428
+    },
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260426",
+      "upgrade-weight": 20260426
+    },
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260425",
+      "upgrade-weight": 20260425
+    },
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260423",
+      "upgrade-weight": 20260423
+    },
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260422",
+      "upgrade-weight": 20260422
+    },
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260420",
+      "upgrade-weight": 20260420
+    },
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260419",
+      "upgrade-weight": 20260419
+    },
+    {
+      "name": "openSUSE Tumbleweed",
+      "version": "20260418",
+      "upgrade-weight": 20260418
+    }
+  ]
+}

--- a/opensuse-migration-tool
+++ b/opensuse-migration-tool
@@ -78,11 +78,21 @@ ARCH=$(uname -i) # x86_64 XXX: check for other arches
 
 # Fetch distribution data from API
 API_URL="https://get.opensuse.org/api/v0/distributions.json"
-API_DATA=$(curl -s "$API_URL")
+API_DATA=$(curl -s --fail "$API_URL")
 if [ $? != 0 ]; then
-    echo "Network error: Unable to fetch release data from https://get.opensuse.org/api/v0/distributions.json"
+    echo "Network error: Unable to fetch release data from $API_URL"
     echo "Ensure that you have working network connectivity and get.opensuse.org is accessible."
-    exit 3
+    echo "Trying local fallback distributions.json ..."
+    if [ -f "$SCRIPT_DIR/distributions.json" ]; then
+        echo "[INFO] Using $SCRIPT_DIR/distributions.json"
+        API_DATA=$(cat "$SCRIPT_DIR/distributions.json")
+    elif [ -f "/usr/share/opensuse-migration-tool/distributions.json" ]; then
+        echo "[INFO] Using /usr/share/opensuse-migration-tool/distributions.json"
+        API_DATA=$(cat "/usr/share/opensuse-migration-tool/distributions.json")
+    else
+        echo "No local distributions.json found. Cannot continue."
+        exit 3
+    fi
 fi
 DRYRUN=""
 TMP_REPO_NAME="tmp-migration-tool-repo" # tmp repo to get sles-release or openSUSE-repos-*
@@ -113,7 +123,7 @@ export DRYRUN
 function fetch_versions() {
     local filter="$1"
     local key="$2"
-    jq -r ".${key}[] | select(${filter}) | .version" <<<"$API_DATA"
+    jq -r ".${key}[] | select(${filter}) | .version + \"|\" + .state" <<<"$API_DATA"
 }
 function populate_options() {
     local key="$1"
@@ -124,10 +134,14 @@ function populate_options() {
     local versions
 
     versions=$(fetch_versions "$filter" "$key")
-    while IFS= read -r version; do
+    while IFS="|" read -r version state; do
         if (( $(bc <<<"$current_version < $version") )); then
             if [[ -z "$min_version" ]] || (( $(bc <<<"$version >= $min_version") )); then
-                MIGRATION_OPTIONS["$CURRENT_INDEX"]="openSUSE $key $version$suffix"
+                local state_suffix=""
+                if [[ "$state" != "Stable" ]]; then
+                    state_suffix=" [$state]"
+                fi
+                MIGRATION_OPTIONS["$CURRENT_INDEX"]="openSUSE $key $version${state_suffix}$suffix"
                 MIGRATION_RAW["$CURRENT_INDEX"]="$version"
                 ((CURRENT_INDEX++))
             fi


### PR DESCRIPTION
* Make [Alpha] [Beta] [RC] pre release states visible
* Prep for airgap migrations and get-o-o outages
* Helps to develop tool in trains
* Add ci workflow to capture any diff in our local copy